### PR TITLE
feat: push nightly images from rhdh-plugins

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -1,0 +1,51 @@
+name: Nightly Build
+
+on:
+  push:
+    branches:
+      - test
+      - main
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout x2ansible
+        uses: actions/checkout@v4
+
+      - name: Checkout rhdh-plugins
+        uses: actions/checkout@v4
+        with:
+          repository: redhat-developer/rhdh-plugins
+          path: rhdh-plugins
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Yarn
+        run: corepack enable && corepack prepare yarn@4 --activate
+
+      - name: Login to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Install workspace dependencies
+        working-directory: rhdh-plugins/workspaces/x2a
+        run: yarn install
+
+      - name: Generate TypeScript declarations
+        working-directory: rhdh-plugins/workspaces/x2a
+        run: yarn tsc
+
+      - name: Build and push dynamic plugins
+        working-directory: rhdh-plugins/workspaces/x2a
+        run: ./scripts/build-dynamic-plugins.sh --push --tag nightly


### PR DESCRIPTION
This donwload the rhdh-plugins main branch, and push images to x2ansible quay organization each night:

Images pushed:
```
quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-x2a-dcr:nightly
quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-x2a-backend:nightly
quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras:nightly
quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-x2a:nightly
quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a:nightly
```