### PR TITLE
feat: push RHDH current versions to docs

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -9,6 +9,10 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -49,3 +53,30 @@ jobs:
       - name: Build and push dynamic plugins
         working-directory: rhdh-plugins/workspaces/x2a
         run: ./scripts/build-dynamic-plugins.sh --push --tag nightly
+
+      - name: Generate plugins report
+        working-directory: rhdh-plugins/workspaces/x2a
+        run: ./scripts/build-dynamic-plugins.sh --report > ${{ github.workspace }}/rhdh-plugins-latest.json
+
+      - name: Check for changes
+        id: changes
+        run: |
+          git add rhdh-plugins-latest.json
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automated/rhdh-plugins-latest-sync
+          commit-message: "chore: update rhdh-plugins-latest.json"
+          title: "chore: update rhdh-plugins-latest.json"
+          body: |
+            Automated PR to update the latest RHDH plugins report.
+
+            This PR was created by the `nightly-build` workflow.
+          add-paths: rhdh-plugins-latest.json


### PR DESCRIPTION
This just push a version of the latest plugins version from the RHDH to the docs.

Example: https://github.com/x2ansible/x2ansible/pull/29/changes