### PR TITLE
Updated app.yaml for the RHDH 1.10

### DIFF
--- a/deploy/app.yaml
+++ b/deploy/app.yaml
@@ -92,16 +92,14 @@ data:
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-mcp-actions-backend:pr_2236__0.1.11"
 
       # Enable backstage-plugin-scaffolder-backend-module-github-dynamic plugin which is disabled by default for better github integration
-      # - package: './dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic'
-      #   disabled: false
+      - package: './dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic'
+        disabled: false
 
       # All X2A plugins
-      - package: "oci://quay.io/mlibra/red-hat-developer-hub-backstage-plugin-x2a:2.0.0"
-      - package: "oci://quay.io/mlibra/red-hat-developer-hub-backstage-plugin-x2a-backend:2.0.0"
-      - package: "oci://quay.io/mlibra/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras:1.0.0"
-      - package: "oci://quay.io/mlibra/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a:1.0.0"
-      
-      # In addition, the backstage-plugin-auth-backend 0.25.6 or later is required, should be met since RHDH 1.9. Keeping this note here for a reference in case of issues.
+      - package: "oci://quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-x2a:2.0.0"
+      - package: "oci://quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-x2a-backend:2.0.0"
+      - package: "oci://quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras:1.0.0"
+      - package: "oci://quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a:1.0.0"
 
 ---
 # ConfigMap: Application Configuration
@@ -253,7 +251,7 @@ data:
     #      - x2a
     #    admin:
     #      users:
-    #        - name: user:default/mareklibra
+    #        - name: user:default/[your-user]
 
     x2a:
       callbackBaseUrl: http://${SERVICE_NAME}.${NAMESPACE}.svc.cluster.local/api/x2a
@@ -295,8 +293,8 @@ spec:
   #   - GCP: standard or standard-rwo
   # List available storage classes: oc get storageclass
   # storageClassName: kubevirt-csi-infra-default
-  # storageClassName: crc-csi-hostpath-provisioner
-  storageClassName: hostpath-csi
+  storageClassName: crc-csi-hostpath-provisioner
+  # storageClassName: hostpath-csi
   resources:
     requests:
       storage: 2Gi

--- a/deploy/app.yaml
+++ b/deploy/app.yaml
@@ -72,26 +72,35 @@ data:
     includes:
       - dynamic-plugins.default.yaml
     plugins:
-      # The plugin-x2a-dcr is for RHDH 1.9 only. To be replaced by backstage-plugin-auth in 1.10:
-      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a-dcr:bs_1.49.4__0.2.0"
+      # Upstream @backstage/plugin-auth frontend providing the /oauth2/* consent page for DCR.
+      # Replaces the x2a-dcr workaround used in RHDH 1.9. Still needed in RHDH 1.10
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth:bs_1.49.4__0.1.6"
 
-      # We need https://github.com/backstage/backstage/blob/master/plugins/mcp-actions-backend/CHANGELOG.md#0112-next2 or later
-      # which contains required fix: https://github.com/backstage/backstage/issues/33062
-      # To match RHDH 1.10 (will be based on Backstage 1.49.4 compatible with mcp-actions-backend:0.1.11), following build is based on mcp-actions-backend:0.1.11 patched for the issues/33062 fix.
-      # This image works well in both RHDH 1.9 (Backstage 1.45.3) and the upcoming RHDH 1.10.
-      # We should not need this custom build in a RHDH 1.10 releases (will be with mcp-actions-backend:0.1.12 or later).
+      # Custom build of mcp-actions-backend based on version 0.1.11, patched for:
+      #   https://github.com/backstage/backstage/issues/33062
+      #
+      # The fix landed in mcp-actions-backend 0.1.12-next.2 (see CHANGELOG) but 0.1.12 has not
+      # been included in a stable Backstage release yet.
+      # RHDH 1.10 is based on Backstage 1.49.4 which ships mcp-actions-backend 0.1.11 (without the fix).
+      # RHDH does not bundle mcp-actions-backend natively - it must be installed as a dynamic plugin.
+      #
+      # Following patched image was built from: https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2236
+      # It works in both RHDH 1.9 (Backstage 1.45.3) and RHDH 1.10 (Backstage 1.49.4).
+      # TODO: Replace with the upstream overlay build once a stable Backstage release includes
+      #       mcp-actions-backend >= 0.1.12 and a matching RHDH overlay image is published.
+      # Expected time frame: RHDH 1.11 or RHDH 2.0
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-mcp-actions-backend:pr_2236__0.1.11"
 
-      # All X2A plugins
-      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a:bs_1.49.4__1.2.1"
-      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a-backend:bs_1.49.4__1.4.0"
-      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras:bs_1.49.4__0.2.0"
-      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a:bs_1.49.4__0.3.1"
-      
       # Enable backstage-plugin-scaffolder-backend-module-github-dynamic plugin which is disabled by default for better github integration
-      - package: './dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic'
-        disabled: false
+      # - package: './dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic'
+      #   disabled: false
 
+      # All X2A plugins
+      - package: "oci://quay.io/mlibra/red-hat-developer-hub-backstage-plugin-x2a:2.0.0"
+      - package: "oci://quay.io/mlibra/red-hat-developer-hub-backstage-plugin-x2a-backend:2.0.0"
+      - package: "oci://quay.io/mlibra/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras:1.0.0"
+      - package: "oci://quay.io/mlibra/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a:1.0.0"
+      
       # In addition, the backstage-plugin-auth-backend 0.25.6 or later is required, should be met since RHDH 1.9. Keeping this note here for a reference in case of issues.
 
 ---
@@ -102,6 +111,18 @@ metadata:
   name: app-config-rhdh
 data:
   app-config-rhdh.yaml: |
+
+    app:
+      extensions:
+        - 'api:app/app-language':
+            config:
+              defaultLanguage: en
+              availableLanguages:
+                - en
+                - de
+                - es
+                - fr
+                - it
 
     backend:
       cors:
@@ -124,14 +145,14 @@ data:
 
     integrations:
       github:
-      - host: github.com
+        - host: github.com
       # CUSTOMIZE:
       # gitlab:
-      # - host: gitlab.com
-      # - host: gitlab.internal.io # Self-hosted GitLab
-      #   apiBaseUrl: https://gitlab.internal.io/api/v4
+      #   - host: gitlab.com
+      #   - host: gitlab.internal.io # Self-hosted GitLab
+      #     apiBaseUrl: https://gitlab.internal.io/api/v4
       # bitbucketCloud:
-      # - host: bitbucket.org
+      #   - host: bitbucket.org
 
     auth:
       experimentalDynamicClientRegistration:
@@ -165,6 +186,9 @@ data:
         #     clientSecret: ${AUTH_BITBUCKET_CLIENT_SECRET:-}
         #     signIn:
         #       resolvers:
+        #         # The usernameMatchingUserEntityName resolver is not working for Bitbucket.
+        #         # Cannot make the bitbucket to provide user's email.
+        #         # See the org.yaml file for an example of how to use the usernameMatchingUserEntityAnnotation resolver.
         #         - resolver: usernameMatchingUserEntityAnnotation
         #           dangerouslyAllowSignInWithoutUserInCatalog: true
 
@@ -175,7 +199,7 @@ data:
         #     clientSecret: ${AUTH_GITLAB_CLIENT_SECRET}
         #     signIn:
         #       resolvers:
-        #         - resolver: emailMatchingUserEntityProfileEmail
+        #         - resolver: usernameMatchingUserEntityName
         #           dangerouslyAllowSignInWithoutUserInCatalog: true
     signInPage:
       - github
@@ -183,20 +207,23 @@ data:
       # - bitbucket
     dynamicPlugins:
       frontend:
-        red-hat-developer-hub.backstage-plugin-x2a-dcr:
+        backstage.plugin-auth:
           dynamicRoutes:
             - path: /oauth2/*
-              importName: DcrConsentPage
+              importName: Router
 
         red-hat-developer-hub.backstage-plugin-x2a:
           scaffolderFieldExtensions:
             - importName: RepoAuthenticationExtension
             - importName: RulesAcceptanceExtension
+          translationResources:
+            - importName: x2aPluginTranslations
+              ref: x2aPluginTranslationRef
           appIcons:
             - name: x2aIcon
               importName: X2AIcon
           dynamicRoutes:
-            - path: /x2a/
+            - path: /x2a
               importName: X2APage
               menuItem:
                 text: Conversion Hub
@@ -209,6 +236,25 @@ data:
           target: /opt/app-root/src/dynamic-plugins-root/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a/templates/conversion-project-template.yaml
           rules:
             - allow: [Template]
+        # CUSTOMIZATION: Remove or update per your organization and identity provider configured above
+        #- type: url
+        #  target: https://raw.githubusercontent.com/[your-org]/org.yaml
+        #  rules:
+        #    - allow: [User, Group]
+
+    # CUSTOMIZATION: see https://backstage.io/docs/permissions/getting-started for more on the permission framework
+    #permission:
+    #  # Set to false to disable RBAC checks
+    #  enabled: true
+    #  rbac:
+    #    policies-csv-file: ../../examples/example-rbac-policy.csv
+    #    policyFileReload: true
+    #    pluginsWithPermission:
+    #      - x2a
+    #    admin:
+    #      users:
+    #        - name: user:default/mareklibra
+
     x2a:
       callbackBaseUrl: http://${SERVICE_NAME}.${NAMESPACE}.svc.cluster.local/api/x2a
       kubernetes:
@@ -249,7 +295,8 @@ spec:
   #   - GCP: standard or standard-rwo
   # List available storage classes: oc get storageclass
   # storageClassName: kubevirt-csi-infra-default
-  storageClassName: crc-csi-hostpath-provisioner
+  # storageClassName: crc-csi-hostpath-provisioner
+  storageClassName: hostpath-csi
   resources:
     requests:
       storage: 2Gi

--- a/deploy/app.yaml
+++ b/deploy/app.yaml
@@ -96,11 +96,10 @@ data:
         disabled: false
 
       # All X2A plugins
-      # TODO: update once https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/3053 gets merged
-      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a:pr_3053__2.0.0"
-      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a-backend:pr_3053__2.0.0"
-      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras:pr_3053__1.0.0"
-      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a:pr_3053__1.0.0"
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a:bs_1.49.4__2.0.0"
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a-backend:bs_1.49.4__2.0.0"
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras:bs_1.49.4__1.0.0"
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a:bs_1.49.4__1.0.0"
 
 ---
 # ConfigMap: Application Configuration

--- a/deploy/app.yaml
+++ b/deploy/app.yaml
@@ -96,10 +96,11 @@ data:
         disabled: false
 
       # All X2A plugins
-      - package: "oci://quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-x2a:2.0.0"
-      - package: "oci://quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-x2a-backend:2.0.0"
-      - package: "oci://quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras:1.0.0"
-      - package: "oci://quay.io/x2ansible/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a:1.0.0"
+      # TODO: update once https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/3053 gets merged
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a:pr_3053__2.0.0"
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a-backend:pr_3053__2.0.0"
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras:pr_3053__1.0.0"
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a:pr_3053__1.0.0"
 
 ---
 # ConfigMap: Application Configuration

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -5,7 +5,7 @@ metadata:
   name: developer-hub-operator-subscription
   namespace: openshift-operators
 spec:
-  channel: "fast-1.9"
+  channel: "fast-1.10"
   installPlanApproval: Automatic
   name: rhdh
   source: redhat-operators

--- a/docs/platform/installation-backstage.md
+++ b/docs/platform/installation-backstage.md
@@ -11,18 +11,15 @@ This guide adds the X2A plugins to a stock Backstage app created with the upstre
 
 Reference implementation and deeper notes live in the Red Hat plugin workspace: [rhdh-plugins/workspaces/x2a](https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/x2a) ([`packages/app`](https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/x2a/packages/app), [`packages/backend`](https://github.com/redhat-developer/rhdh-plugins/tree/main/workspaces/x2a/packages/backend)).
 
-The plugins are currently tested against **Backstage 1.45.3** (conforms RHDH 1.9). Other Backstage versions may work but are not guaranteed.
+The plugins are currently tested against **Backstage 1.49.4** (conforms RHDH 1.10). Other Backstage versions may work but are not guaranteed. Since **RHDH 1.10.2**, only the New Frontend System (NFS) is supported.
 
 ## Prerequisites
 
-Follow [Standalone Installation](https://backstage.io/docs/getting-started/), but create the app with the **legacy** stack so the X2A plugins work with the current APIs:
+Follow [Standalone Installation](https://backstage.io/docs/getting-started/) to create a new Backstage app:
 
 ```bash
-npx @backstage/create-app@latest --legacy
+npx @backstage/create-app@latest
 ```
-
-The X2A plugins are not yet adapted to [Backstage's new frontend system](https://backstage.io/docs/frontend-system/) - that migration is in progress.
-Until it lands, you must use `--legacy` when generating the app.
 
 Additionally, for X2A you need:
 
@@ -68,7 +65,7 @@ backend.add(import('@backstage/plugin-scaffolder-backend'));
 // Add GitHub / GitLab / Bitbucket scaffolder modules to match the auth providers you enable.
 backend.add(import('@backstage/plugin-scaffolder-backend-module-github'));
 backend.add(import('@backstage/plugin-scaffolder-backend-module-gitlab'));
-backend.add(import('@backstage/plugin-scaffolder-backend-module-bitbucket'));
+backend.add(import('@backstage/plugin-scaffolder-backend-module-bitbucket-cloud'));
 backend.add(
   import('@red-hat-developer-hub/backstage-plugin-scaffolder-backend-module-x2a'),
 );
@@ -82,78 +79,49 @@ backend.add(import('@backstage/plugin-mcp-actions-backend'));
 backend.add(import('@red-hat-developer-hub/backstage-plugin-x2a-mcp-extras'));
 ```
 
-## Register frontend routes and scaffolder extension
+## Register the frontend plugin
 
-In `packages/app/src/App.tsx` (adjust imports to match your existing `create-app` layout):
-
-1. Import the X2A page, translations, and repo field extension:
+The X2A plugin integrates with Backstage's [New Frontend System](https://backstage.io/docs/frontend-system/). In `packages/app/src/App.tsx`, import the plugin and add it to the `features` array:
 
 ```tsx
-import {
-  X2APage,
-  x2aPluginTranslations,
-  RepoAuthenticationExtension,
-} from '@red-hat-developer-hub/backstage-plugin-x2a';
-```
+import { createApp } from '@backstage/frontend-defaults';
+import catalogPlugin from '@backstage/plugin-catalog/alpha';
+import scaffolderPlugin from '@backstage/plugin-scaffolder/alpha';
+import userSettingsPlugin from '@backstage/plugin-user-settings/alpha';
+import x2aPlugin, {
+  x2aTranslationsModule,
+} from '@red-hat-developer-hub/backstage-plugin-x2a/alpha';
 
-2. If you use **OAuth DCR** and installed `backstage-plugin-x2a-dcr`:
-
-```tsx
-import { DcrConsentPage } from '@red-hat-developer-hub/backstage-plugin-x2a-dcr';
-```
-
-3. Pass plugin strings into `createApp`:
-
-```tsx
-const app = createApp({
-  // ...apis, bindRoutes, components, etc.
-  __experimentalTranslations: {
-    availableLanguages: ['en'], // add more if you use them elsewhere
-    resources: [x2aPluginTranslations],
-  },
+export default createApp({
+  features: [
+    catalogPlugin,
+    scaffolderPlugin,
+    userSettingsPlugin,
+    x2aPlugin,
+    x2aTranslationsModule,
+  ],
 });
 ```
 
-4. Add a route for the portal (path is `/x2a`, not `/x2a/`):
+That is all that is needed. The plugin self-registers its `/x2a` route, sidebar entry, and scaffolder field extensions through the frontend system.
 
-```tsx
-<Route path="/x2a" element={<X2APage />} />
+### Language configuration
+
+To enable multi-language support, add the following to your `app-config.yaml`:
+
+```yaml
+app:
+  extensions:
+    - 'api:app/app-language':
+        config:
+          defaultLanguage: en
+          availableLanguages:
+            - en
+            - de
+            - es
+            - fr
+            - it
 ```
-
-5. Wrap the scaffolder page so the conversion template can use the **Repo authentication** custom field (same pattern as the [reference `App.tsx`](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/x2a/packages/app/src/App.tsx)):
-
-```tsx
-import { ScaffolderPage } from '@backstage/plugin-scaffolder';
-import { ScaffolderFieldExtensions } from '@backstage/plugin-scaffolder-react';
-
-<Route path="/create" element={<ScaffolderPage />}>
-  <ScaffolderFieldExtensions>
-    <RepoAuthenticationExtension />
-  </ScaffolderFieldExtensions>
-</Route>
-```
-
-6. Optional DCR consent route:
-
-```tsx
-<Route path="/oauth2/*" element={<DcrConsentPage />} />
-```
-
-If repository OAuth behaves oddly, compare `packages/app/src/apis.ts` with the [reference `apis.ts`](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/x2a/packages/app/src/apis.ts) (`ScmIntegrationsApi`, `ScmAuth`).
-
-### Sidebar: Conversion Hub
-
-Static routes do not add a sidebar label by themselves (RHDH injects menu text via dynamic plugin metadata). In `packages/app/src/components/Root.tsx`, add an item next to your other `SidebarItem` entries (adjust the icon import if your app uses `@mui/icons-material` instead of `@material-ui/icons`):
-
-```tsx
-import { SidebarItem } from '@backstage/core-components';
-import ExtensionIcon from '@material-ui/icons/Extension';
-
-// Inside the main <SidebarGroup label="Menu" ...> (or equivalent).
-<SidebarItem icon={ExtensionIcon} to="x2a" text="Conversion Hub" />
-```
-
-`to="x2a"` matches the `/x2a` route registered in `App.tsx`.
 
 ## Catalog: register the conversion template
 
@@ -173,12 +141,12 @@ CSV-driven bulk flows and the `RepoAuthentication` extension are described in [C
 
 ## Configuration (pointers only)
 
-| Topic | Where it is documented |
-|--------|-------------------------|
-| OAuth providers, env vars, sign-in | [Authentication]({% link platform/authentication.md %}) |
-| RBAC / permissions for the `x2a` plugin | [Authorization]({% link platform/authorization.md %}) |
-| `x2a:` Kubernetes image, job resources, LLM and AAP credentials | [X2A backend plugin README](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/x2a/plugins/x2a-backend/README.md) and [reference app-config.yaml](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/x2a/app-config.yaml) |
-| SCM host detection (GitHub Enterprise, self-hosted GitLab, etc.) | [Workspace README — SCM Provider Detection](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/x2a/README.md) (`integrations:` host entries; tokens there are not used for X2A repo auth; OAuth applies.) |
+| Topic                                                            | Where it is documented                                                                                                                                                                                                                                          |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OAuth providers, env vars, sign-in                               | [Authentication]({% link platform/authentication.md %})                                                                                                                                                                                                         |
+| RBAC / permissions for the `x2a` plugin                          | [Authorization]({% link platform/authorization.md %})                                                                                                                                                                                                           |
+| `x2a:` Kubernetes image, job resources, LLM and AAP credentials  | [X2A backend plugin README](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/x2a/plugins/x2a-backend/README.md) and [reference app-config.yaml](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/x2a/app-config.yaml) |
+| SCM host detection (GitHub Enterprise, self-hosted GitLab, etc.) | [Workspace README — SCM Provider Detection](https://github.com/redhat-developer/rhdh-plugins/blob/main/workspaces/x2a/README.md) (`integrations:` host entries; tokens there are not used for X2A repo auth; OAuth applies.)                                    |
 
 If the backend API base URL seen by clients or integrations is not the default, you may need `x2a.callbackBaseUrl` (see in-cluster example in [deploy/app.yaml](https://github.com/x2ansible/x2ansible.github.io/blob/main/deploy/app.yaml)); local `yarn start` often works without it.
 
@@ -194,3 +162,12 @@ In the catalog, confirm the **conversion project** template appears (might take 
 ## API exploration
 
 Use [API Reference]({% link platform/api-reference.md %}) for the REST surface once the backend plugin is running.
+
+---
+
+## Legacy frontend system
+
+{: .warning }
+Since **RHDH 1.10.2**, only the [New Frontend System](https://backstage.io/docs/frontend-system/) (NFS) is supported.
+Apps created with `npx @backstage/create-app@latest --legacy` (or otherwise using the old frontend wiring) are not supported.
+Follow [Register the frontend plugin](#register-the-frontend-plugin) above.

--- a/docs/platform/installation-backstage.md
+++ b/docs/platform/installation-backstage.md
@@ -44,16 +44,39 @@ Published packages (verify versions before pinning in production):
 
 ### Optional components
 
-Only if you need OAuth Dynamic Client Registration UI and/or MCP tool wiring similar to production RHDH overlays:
+Core X2A conversion flows do not require the packages below. Add them only when you need DCR consent UI and/or MCP tool wiring similar to the production RHDH overlays in [`deploy/app.yaml`](https://github.com/x2ansible/x2ansible.github.io/blob/main/deploy/app.yaml).
+
+#### OAuth Dynamic Client Registration (DCR)
+
+Since RHDH 1.10, the `/oauth2/*` consent page comes from upstream [`@backstage/plugin-auth`](https://www.npmjs.com/package/@backstage/plugin-auth) (replacing the RHDH 1.9-only `x2a-dcr` workaround):
 
 ```bash
-yarn --cwd packages/app add @red-hat-developer-hub/backstage-plugin-x2a-dcr
+yarn --cwd packages/app add @backstage/plugin-auth
+```
+
+Add the plugin to the NFS `features` array in `App.tsx` (see [Register the frontend plugin](#register-the-frontend-plugin)):
+
+```tsx
+import authPlugin from '@backstage/plugin-auth';
+
+export default createApp({
+  features: [
+    // ...catalogPlugin, scaffolderPlugin, x2aPlugin, etc.
+    authPlugin,
+  ],
+});
+```
+
+Enable DCR under `auth.experimentalDynamicClientRegistration` in `app-config.yaml`. For a full example, see [`deploy/app.yaml`](https://github.com/x2ansible/x2ansible.github.io/blob/main/deploy/app.yaml).
+
+#### MCP tools
+
+```bash
 yarn --cwd packages/backend add @backstage/plugin-mcp-actions-backend
 yarn --cwd packages/backend add @red-hat-developer-hub/backstage-plugin-x2a-mcp-extras
 ```
 
 For `mcpActions` and related `app-config` fragments, see [MCP tools - Advanced configuration]({% link platform/mcp-server.md %}#advanced-configuration).
-Core X2A conversion flows do not require these packages.
 
 ## Register backend plugins
 

--- a/docs/platform/installation.md
+++ b/docs/platform/installation.md
@@ -142,7 +142,7 @@ oc apply -n my-custom-namespace -f deploy/app.yaml
 
 ### Plugin Versions
 
-To use different plugin versions, update the OCI image references in the `dynamic-plugins` ConfigMap section of `deploy/app.yaml`. The default manifest also includes the MCP server, X2A MCP extras, and DCR consent UI packages alongside the Conversion Hub plugins.
+To use different plugin versions, update the OCI image references in the `dynamic-plugins` ConfigMap section of `deploy/app.yaml`. The default manifest also includes the MCP server, X2A MCP extras, and the upstream `@backstage/plugin-auth` DCR consent UI alongside the Conversion Hub plugins.
 
 ## MCP tools
 

--- a/docs/platform/mcp-server.md
+++ b/docs/platform/mcp-server.md
@@ -57,7 +57,7 @@ If a browser-based client fails with CORS errors against your public route, incl
 
 ### Delegated access (default)
 
-The default manifest enables **OAuth2 Dynamic Client Registration (DCR)** under `auth.experimentalDynamicClientRegistration` and installs the X2A DCR frontend so consent can be served under `/oauth2/*`.
+The default manifest enables **OAuth2 Dynamic Client Registration (DCR)** under `auth.experimentalDynamicClientRegistration` and installs the upstream `@backstage/plugin-auth` frontend so consent can be served under `/oauth2/*`.
 In typical use, the MCP client starts registration, the user signs in or approves access in the browser and subsequent tool calls run **on behalf of that user** with their RHDH identity and RBAC.
 
 High-level sequence:


### PR DESCRIPTION
Changes based on testing https://github.com/redhat-developer/rhdh-plugins/pull/3321 with RHDH 1.10 in an OCP cluster.

TODO:
- [x] update test-only images to quay.io/x2ansible once https://github.com/redhat-developer/rhdh-plugins/pull/3321 get merged
- [x] test the DCR flow (newly with upstream @backstage/auth)
- [x] comment-out org data section -keep it as an example only
- [x] restore `storageClassName`