### PR TITLE
enbaling github-scaffolder plugin

### DIFF
--- a/deploy/app.yaml
+++ b/deploy/app.yaml
@@ -87,6 +87,10 @@ data:
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a-backend:bs_1.49.4__1.4.0"
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-x2a-mcp-extras:bs_1.49.4__0.2.0"
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-x2a:bs_1.49.4__0.3.1"
+      
+      # Enable backstage-plugin-scaffolder-backend-module-github-dynamic plugin which is disabled by default for better github integration
+      - package: './dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic'
+        disabled: false
 
       # In addition, the backstage-plugin-auth-backend 0.25.6 or later is required, should be met since RHDH 1.9. Keeping this note here for a reference in case of issues.
 


### PR DESCRIPTION
   ### Issue
   Fix FLPATH-4408 - GitHub autocomplete request fails at RHDH

   ### Problem
   When creating a new project in RHDH Conversion Hub, the GitHub repository autocomplete fails with a 400 error on
   the "Source and target repositories" page.

   **Error:**
   ```
   POST /v2/autocomplete/github/repositoriesWithOwner
   Response: 400 Bad Request
   Error: "Unsupported provider: github"
   ```

   ### Root Cause
   The `backstage-plugin-scaffolder-backend-module-github` is disabled in our instance of RHDH's default configuration.    This module provides the autocomplete endpoint for GitHub repositories. Without it enabled, GitHub is not recognized as a supported SCM provider for the scaffolder.

   Works locally because `packages/backend/src/index.ts` directly imports the module, but RHDH uses dynamic plugin
   configuration.

   ### Changes
   Enable the GitHub scaffolder backend module in dynamic plugins configuration:

