### PR TITLE
fix: enable guest sign-in provider for RHDH 1.11 compatibility

### DIFF
--- a/deploy/app.yaml
+++ b/deploy/app.yaml
@@ -147,7 +147,7 @@ data:
       environment: development
       providers:
         # See https://backstage.io/docs/auth/guest/provider
-        # guest: {}
+        guest: {}
 
         # CUSTOMIZE:
         github:
@@ -179,6 +179,7 @@ data:
         #           dangerouslyAllowSignInWithoutUserInCatalog: true
     signInPage:
       - github
+      - guest
       # - gitlab
       # - bitbucket
     dynamicPlugins:


### PR DESCRIPTION
## Summary

- Uncomment `guest: {}` auth provider (was already enabled by CI pipeline at deploy time)
- Add `guest` to `signInPage` array so the sign-in page properly handles the guest login flow in RHDH 1.11

## Problem

RHDH 1.11 changed sign-in page behavior: the guest login UI flow no longer completes when `guest` is not listed in `signInPage`. The **Enter** button appears and backend auth succeeds (tokens issued via `/api/auth/guest/refresh` → 200), but the frontend sign-in overlay does not dismiss — leaving the sidebar `<nav>` hidden.

This broke all 6 UI smoke tests in CI builds #1349–1353 (`flightpath-x2ansible`).

**Last stable build:** #1348 (RHDH 1.10) — all 6 UI tests passed
**First broken build:** #1349 (RHDH 1.11) — all 6 UI tests fail with `Test timeout of 60000ms exceeded` waiting for `locator('nav').first()` to become visible

## Evidence

- Backend logs confirm guest auth works: `auth info Issuing token for user:development/guest`
- Playwright error: `115 × locator resolved to hidden <nav aria-label="sidebar nav">…</nav>`
- RHDH route returns HTTP 200, all dynamic plugin chunks load successfully

## Attribution

Requested by: <@UTKKVT884> (gharden)
Channel: #C0ADFHCVB46
Triaged by: qe-ci-ai-bot